### PR TITLE
Use specific Flask version (`Flask>=0.10,<0.11`); fix `setup.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *#
 .#*
 *TAGS
+*.egg-info
 .ropeproject
 /data
 static/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ behave==1.2.5
 wooper==0.4.2
 gunicorn==19.4.5
 honcho==0.6.6
+Flask>=0.10,<0.11
 Flask-OAuthlib==0.9.1
 flask-sentinel==0.0.4
 Eve==0.6.3

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     url='https://github.com/superdesk/superdesk-content-api',
     license='GPLv3',
     platforms=['any'],
-    packages=find_packages('content_api'),
+    packages=find_packages(exclude=['features']),
     install_requires=REQUIREMENTS,
     scripts=[
         'content_api_manage.py',


### PR DESCRIPTION
Regarding latest errors:

```
15:53:07 contentapi.1 | During handling of the above exception, another exception occurred:
15:53:07 contentapi.1 | 
15:53:07 contentapi.1 | Traceback (most recent call last):
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1988, in wsgi_app
15:53:07 contentapi.1 |     response = self.full_dispatch_request()
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1641, in full_dispatch_request
15:53:07 contentapi.1 |     rv = self.handle_user_exception(e)
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1539, in handle_user_exception
15:53:07 contentapi.1 |     return self.handle_http_exception(e)
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1495, in handle_http_exception
15:53:07 contentapi.1 |     handler = self._find_error_handler(e)
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1476, in _find_error_handler
15:53:07 contentapi.1 |     .get(code))
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1465, in find_handler
15:53:07 contentapi.1 |     handler = handler_map.get(cls)
15:53:07 contentapi.1 | AttributeError: 'function' object has no attribute 'get'
15:53:07 contentapi.1 | 'function' object has no attribute 'get'
15:53:07 contentapi.1 | Traceback (most recent call last):
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1639, in full_dispatch_request
15:53:07 contentapi.1 |     rv = self.dispatch_request()
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1625, in dispatch_request
15:53:07 contentapi.1 |     return self.view_functions[rule.endpoint](**req.view_args)
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/eve/methods/common.py", line 242, in rate_limited
15:53:07 contentapi.1 |     return f(*args, **kwargs)
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/eve/auth.py", line 78, in decorated
15:53:07 contentapi.1 |     return auth.authenticate()
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/eve/auth.py", line 138, in authenticate
15:53:07 contentapi.1 |     response=resp)
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/werkzeug/exceptions.py", line 646, in __call__
15:53:07 contentapi.1 |     raise self.mapping[code](*args, **kwargs)
15:53:07 contentapi.1 | werkzeug.exceptions.Unauthorized: 401: Unauthorized
15:53:07 contentapi.1 | 
15:53:07 contentapi.1 | During handling of the above exception, another exception occurred:
15:53:07 contentapi.1 | 
15:53:07 contentapi.1 | Traceback (most recent call last):
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1988, in wsgi_app
15:53:07 contentapi.1 |     response = self.full_dispatch_request()
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1641, in full_dispatch_request
15:53:07 contentapi.1 |     rv = self.handle_user_exception(e)
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1539, in handle_user_exception
15:53:07 contentapi.1 |     return self.handle_http_exception(e)
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1495, in handle_http_exception
15:53:07 contentapi.1 |     handler = self._find_error_handler(e)
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1476, in _find_error_handler
15:53:07 contentapi.1 |     .get(code))
15:53:07 contentapi.1 |   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1465, in find_handler
15:53:07 contentapi.1 |     handler = handler_map.get(cls)
15:53:07 contentapi.1 | AttributeError: 'function' object has no attribute 'get'
15:53:07 contentapi.1 | HTTP Exception 500 has been raised: None
```
